### PR TITLE
Fix bug in run_logo.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM proteinphysiologylab/frustraevo:latest
-
-RUN rm -r /root/FrustraEvo 
-
-WORKDIR /opt
-
-RUN git clone https://github.com/FranceCosta/FrustraEvo.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM proteinphysiologylab/frustraevo:latest
+
+RUN rm -r /root/FrustraEvo 
+
+WORKDIR /opt
+
+RUN git clone https://github.com/FranceCosta/FrustraEvo.git

--- a/Functions.py
+++ b/Functions.py
@@ -4,7 +4,6 @@ import re
 import sys
 from Bio import SeqIO
 import numpy as np
-from scipy.cluster.hierarchy import linkage, dendrogram
 import warnings
 from Bio import BiopythonWarning
 warnings.simplefilter('ignore', BiopythonWarning)

--- a/run_logo.py
+++ b/run_logo.py
@@ -11,7 +11,7 @@ parser.add_argument("--RPath", default='Scripts', help="Path to R script files (
 parser.add_argument("--fasta", help="Name of the fasta")
 parser.add_argument("--ref", default='None', help="Id of the reference protein of your logo (Default: None)")
 parser.add_argument("--pdb_db", default='None', help="Path to the PDBs folder (Default: None)")
-parser.add_argument("--cmaps", default='None', help="Put 'yes' for contactmaps calculation (Default: None)")
+parser.add_argument("--cmaps", default='no', choices=["yes", "no"], help="Put 'yes' for contactmaps calculation (Default: None)")
 
 
 #How to run the pipeline in linux terminal:
@@ -49,8 +49,7 @@ if args.cmaps == 'yes':
         Functions.CMaps_Mutational(args.JobId,args.RPath,args.ref)#Genera los mapas de contacto para el indice mutational
         print('Running CMaps for Configurational')
         Functions.CMaps_Configurational(args.JobId,args.RPath,args.ref)#Genera los mapas de contacto para el indice configurational
-else:
-        args.cmaps = 'no'
+
 Functions.clean_files(args.JobId,args.RPath,args.ref,args.cmaps)
 print('Making Visualization scripts (.pml)')
 Functions.VScript(args.JobId)

--- a/run_logo.py
+++ b/run_logo.py
@@ -11,7 +11,7 @@ parser.add_argument("--RPath", default='Scripts', help="Path to R script files (
 parser.add_argument("--fasta", help="Name of the fasta")
 parser.add_argument("--ref", default='None', help="Id of the reference protein of your logo (Default: None)")
 parser.add_argument("--pdb_db", default='None', help="Path to the PDBs folder (Default: None)")
-parser.add_argument("--cmaps", default='no', choices=["yes", "no"], help="Put 'yes' for contactmaps calculation (Default: None)")
+parser.add_argument("--cmaps", default='no', choices=["yes", "no"], help="Put 'yes' for contactmaps calculation (Default: 'no')")
 
 
 #How to run the pipeline in linux terminal:


### PR DESCRIPTION
I have fixed a bug in the run_logo.py script. The --cmap argument was by default set to None and this caused an error when running `Functions.clean_files(args.JobId,args.RPath,args.ref,args.cmaps)` because `args.cmaps = 'no'` does not work as intended since argparse arguments cannot be modified. I have set the default value of --cmap to 'no' and set as allowed arguments only 'yes' or 'no' to remove ambiguity. 

I have also created a docker container that can be easierly deployed on a computer cluster via Singularity, which you can find here:
https://hub.docker.com/repository/docker/francecosta/frustraevosing/general

I just nedeed to move FrustraEvo from /root to another location (/opt).